### PR TITLE
Fix MacOS SDL3 build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -66,6 +66,14 @@ pub fn build(b: *std.Build) void {
         .files = srcs,
     });
 
+    if (target.result.os.tag == .macos) {
+        lib.addCSourceFile(.{
+            .file = upstream.path("src/IMG_ImageIO.m"),
+        });
+        lib.linkFramework("Foundation");
+        lib.linkFramework("ApplicationServices");
+    }
+
     lib.installHeadersDirectory(upstream.path("include"), "", .{});
 
     b.installArtifact(lib);


### PR DESCRIPTION
This `IMG_ImageIO.m` file is required to build on MacOS.