### PR TITLE
Fix MacOS SDL2 build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -68,6 +68,14 @@ pub fn build(b: *std.Build) void {
         .files = srcs,
     });
 
+    if (target.result.os.tag == .macos) {
+        lib.addCSourceFile(.{
+            .file = upstream.path("src/IMG_ImageIO.m"),
+        });
+        lib.linkFramework("Foundation");
+        lib.linkFramework("ApplicationServices");
+    }
+
     lib.installHeader(upstream.path("include/SDL_image.h"), "SDL2/SDL_image.h");
 
     b.installArtifact(lib);


### PR DESCRIPTION
This `IMG_ImageIO.m` file is required to build on MacOS.
